### PR TITLE
Added path, port and scheme support by handling URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,21 +28,8 @@ The output is 3 columns, separated by spaces. The first column is either "MATCH"
 
 ```
 hakluke$ prips 1.1.1.0/24 | hakoriginfinder -l 500 -h https://one.one.one.one/index.html
-NOMATCH http://1.1.1.0/index.html 56506
-NOMATCH http://1.1.1.9/index.html 56506
-NOMATCH http://1.1.1.30/index.html 56506
-NOMATCH http://1.1.1.20/index.html 56506
-NOMATCH http://1.1.1.16/index.html 56506
-NOMATCH http://1.1.1.24/index.html 56506
-NOMATCH http://1.1.1.10/index.html 56506
-NOMATCH http://1.1.1.17/index.html 56506
-NOMATCH http://1.1.1.4/index.html 56506
-... snipped for brevity ...
-NOMATCH http://1.1.1.254/index.html 56506
-NOMATCH http://1.1.1.253/index.html 56506
-MATCH http://1.1.1.1/index.html 228
-NOMATCH http://1.1.1.2/index.html 19487
-NOMATCH http://1.1.1.3/index.html 19487
+Redirect 308 to: https://one.one.one.one/
+MATCH https://1.1.1.1/ 228
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The output is 3 columns, separated by spaces. The first column is either "MATCH"
 ### Output example
 
 ```
-hakluke$ prips 1.1.1.0/24 | ./hakoriginfinder -h https://one.one.one.one/index.html
+hakluke$ prips 1.1.1.0/24 | hakoriginfinder -h https://one.one.one.one/index.html
 Redirect 308 to: https://one.one.one.one/
 NOMATCH https://1.1.1.2/ 56383
 NOMATCH https://1.1.1.3/ 56383

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Tool for discovering the origin host behind a reverse proxy. Useful for bypassin
 
 ## How does it work?
 
-This tool will first make a HTTP request to the hostname that you provide and store the response, then it will make a request to every IP address that you provide via HTTP (80) and HTTPS (443), with the `Host` header set to the original host. Each HTTP response is then compared to the original using the Levenshtein algorithm to determine similarity. If the response is similar, it will be deemed a match.
+This tool will first make a HTTP request to the hostname/URL that you provide and store the response, then it will make a request to every IP address that you provide via HTTP (80) or HTTPS (443) depending on URL, with the `Host` header set to the original host(:port). Each response is then compared to the original using the Levenshtein algorithm to determine similarity. If the response is similar, it will be deemed a match.
 
 ## Usage
 
 Provide the list of IP addresses via stdin, and the original hostname via the -h option. For example:
 
 ```
-prips 93.184.216.0/24 | hakoriginfinder -h example.com
+prips 93.184.216.0/24 | hakoriginfinder -h https://example.com:443/foo
 ```
 
 You may set the Levenshtein distance threshold with `-l`. The lower the number, the more similar the matches need to be for it to be considered a match, the default is 5.
@@ -27,27 +27,22 @@ The output is 3 columns, separated by spaces. The first column is either "MATCH"
 ### Output example
 
 ```
-hakluke$ prips 1.1.1.0/24 | hakoriginfinder -h one.one.one.one
-NOMATCH http://1.1.1.0 54366
-NOMATCH http://1.1.1.30 54366
-NOMATCH http://1.1.1.20 54366
-NOMATCH http://1.1.1.4 54366
-NOMATCH http://1.1.1.11 54366
-NOMATCH http://1.1.1.5 54366
-NOMATCH http://1.1.1.22 54366
-NOMATCH http://1.1.1.13 54366
-NOMATCH http://1.1.1.10 54366
-NOMATCH http://1.1.1.25 54366
-NOMATCH http://1.1.1.19 54366
+hakluke$ prips 1.1.1.0/24 | hakoriginfinder -l 500 -h https://one.one.one.one/index.html
+NOMATCH http://1.1.1.0/index.html 56506
+NOMATCH http://1.1.1.9/index.html 56506
+NOMATCH http://1.1.1.30/index.html 56506
+NOMATCH http://1.1.1.20/index.html 56506
+NOMATCH http://1.1.1.16/index.html 56506
+NOMATCH http://1.1.1.24/index.html 56506
+NOMATCH http://1.1.1.10/index.html 56506
+NOMATCH http://1.1.1.17/index.html 56506
+NOMATCH http://1.1.1.4/index.html 56506
 ... snipped for brevity ...
-NOMATCH http://1.1.1.251 54366
-NOMATCH http://1.1.1.248 54366
-MATCH http://1.1.1.1 0
-NOMATCH http://1.1.1.3 19567
-NOMATCH http://1.1.1.2 19517
-MATCH https://1.1.1.1 0
-NOMATCH https://1.1.1.3 19534
-NOMATCH https://1.1.1.2 19532
+NOMATCH http://1.1.1.254/index.html 56506
+NOMATCH http://1.1.1.253/index.html 56506
+MATCH http://1.1.1.1/index.html 228
+NOMATCH http://1.1.1.2/index.html 19487
+NOMATCH http://1.1.1.3/index.html 19487
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ The output is 3 columns, separated by spaces. The first column is either "MATCH"
 ### Output example
 
 ```
-hakluke$ prips 1.1.1.0/24 | hakoriginfinder -l 500 -h https://one.one.one.one/index.html
+hakluke$ prips 1.1.1.0/24 | ./hakoriginfinder -h https://one.one.one.one/index.html
 Redirect 308 to: https://one.one.one.one/
-MATCH https://1.1.1.1/ 228
+NOMATCH https://1.1.1.2/ 56383
+NOMATCH https://1.1.1.3/ 56383
+MATCH https://1.1.1.1/ 0
 ```
 
 ## Installation

--- a/hakoriginfinder.go
+++ b/hakoriginfinder.go
@@ -68,7 +68,15 @@ func worker(ips <-chan string, resChan chan<- string, wg *sync.WaitGroup, client
                 if portPos != -1 {
                         port = u.Host[portPos:]
                 }
+
+                // Check if ip address from stdin is ipv6
+                if strings.Count(ip, ":") >= 2 {
+                        ip = "[" + ip + "]"
+                }
+
+                // Create ip URL
                 ipUrl := u.Scheme + "://" + ip + port + u.Path
+                
                 
                 // Create a request
                 req, err := http.NewRequest("GET", ipUrl, nil)

--- a/hakoriginfinder.go
+++ b/hakoriginfinder.go
@@ -78,7 +78,7 @@ func worker(ips <-chan string, resChan chan<- string, wg *sync.WaitGroup, client
                 }
 
                 // Add the custom host header to the request (can be host:port)
-                req.Header.Add("Host", u.Host)
+                req.Host = u.Host
 
                 // Do the request
                 resp, err := client.Do(req)


### PR DESCRIPTION
The hakoriginfinder program now handles URL as structure where the hostname given with the -h option can be an URL, e.g.
```
prips 1.1.1.0/24 | hakoriginfinder -l 500 -h http://one.one.one.one:80/index.html
--- snip ---
NOMATCH http://1.1.1.254:80/index.html 56506
MATCH http://1.1.1.1:80/index.html 228
NOMATCH http://1.1.1.3:80/index.html 19487
```
EDIT: The 228 distance above is due to a request header host bug, fixed in later commit.

This pull request pretty much fixes: https://github.com/hakluke/hakoriginfinder/issues/7

The behavior has changed regarding HTTPS vs HTTP, it will now only do the scheme/protocol (e.g. https) depending on the "-h" hostname/URL provided regarding the IP checking. Also, the URL with port and path is now also reflected in the piped IP addresses tested, the request header "Host" is only host(:port) as per standard (not the full URL).

I can understand if some of these changes goes against the way you want to handle things, especially regarding HTTP/HTTPS which used to run for both regardless of "-h" hostname scheme/protocol provided, so feel free to ignore this pull request if that is the case.

BTW:
The one.one.one.one site gives 228 in Levenshtein distance for the correct IP address (1.1.1.1), this was before I made any changes with the old version, just so you know not to expect 0 when testing. EDIT: This was a bug, check later commit.

I'm not experienced with golang, so please check for any mistakes and change as you like.