### PR TITLE
Revert "Added path, port and scheme support by handling URL"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Tool for discovering the origin host behind a reverse proxy. Useful for bypassin
 
 ## How does it work?
 
-This tool will first make a HTTP request to the hostname/URL that you provide and store the response, then it will make a request to every IP address that you provide via HTTP (80) or HTTPS (443) depending on URL, with the `Host` header set to the original host(:port). Each response is then compared to the original using the Levenshtein algorithm to determine similarity. If the response is similar, it will be deemed a match.
+This tool will first make a HTTP request to the hostname that you provide and store the response, then it will make a request to every IP address that you provide via HTTP (80) and HTTPS (443), with the `Host` header set to the original host. Each HTTP response is then compared to the original using the Levenshtein algorithm to determine similarity. If the response is similar, it will be deemed a match.
 
 ## Usage
 
 Provide the list of IP addresses via stdin, and the original hostname via the -h option. For example:
 
 ```
-prips 93.184.216.0/24 | hakoriginfinder -h https://example.com:443/foo
+prips 93.184.216.0/24 | hakoriginfinder -h example.com
 ```
 
 You may set the Levenshtein distance threshold with `-l`. The lower the number, the more similar the matches need to be for it to be considered a match, the default is 5.
@@ -27,11 +27,27 @@ The output is 3 columns, separated by spaces. The first column is either "MATCH"
 ### Output example
 
 ```
-hakluke$ prips 1.1.1.0/24 | hakoriginfinder -h https://one.one.one.one/index.html
-Redirect 308 to: https://one.one.one.one/
-NOMATCH https://1.1.1.2/ 56383
-NOMATCH https://1.1.1.3/ 56383
-MATCH https://1.1.1.1/ 0
+hakluke$ prips 1.1.1.0/24 | hakoriginfinder -h one.one.one.one
+NOMATCH http://1.1.1.0 54366
+NOMATCH http://1.1.1.30 54366
+NOMATCH http://1.1.1.20 54366
+NOMATCH http://1.1.1.4 54366
+NOMATCH http://1.1.1.11 54366
+NOMATCH http://1.1.1.5 54366
+NOMATCH http://1.1.1.22 54366
+NOMATCH http://1.1.1.13 54366
+NOMATCH http://1.1.1.10 54366
+NOMATCH http://1.1.1.25 54366
+NOMATCH http://1.1.1.19 54366
+... snipped for brevity ...
+NOMATCH http://1.1.1.251 54366
+NOMATCH http://1.1.1.248 54366
+MATCH http://1.1.1.1 0
+NOMATCH http://1.1.1.3 19567
+NOMATCH http://1.1.1.2 19517
+MATCH https://1.1.1.1 0
+NOMATCH https://1.1.1.3 19534
+NOMATCH https://1.1.1.2 19532
 ```
 
 ## Installation

--- a/hakoriginfinder.go
+++ b/hakoriginfinder.go
@@ -3,16 +3,13 @@ package main
 import (
         "bufio"
         "crypto/tls"
-        "errors"
         "flag"
         "fmt"
         "io/ioutil"
         "log"
         "net/http"
-        "net/url"
         "os"
         "strconv"
-        "strings"
         "sync"
         "time"
 )
@@ -58,58 +55,46 @@ func minimum(a, b, c int) int {
 }
 
 // Make HTTP request, check response
-func worker(ips <-chan string, resChan chan<- string, wg *sync.WaitGroup, client *http.Client, u *url.URL, ogBody string, threshold int) {
+func worker(ips <-chan string, resChan chan<- string, wg *sync.WaitGroup, client *http.Client, hostname string, ogBody string, threshold int) {
         defer wg.Done()
         for ip := range ips {
 
-                // Handle port and url strings
-                port := ""
-                portPos := strings.Index(u.Host, ":")
-                if portPos != -1 {
-                        port = u.Host[portPos:]
+                // make a http and https url
+                urls := []string{"http://" + ip, "https://" + ip}
+
+                for _, url := range urls {
+                        // Create a request
+                        req, err := http.NewRequest("GET", url, nil)
+                        if err != nil {
+                                fmt.Println("Error sending HTTP request", err)
+                                continue
+                        }
+
+                        // Add the custom host header to the request
+                        req.Header.Add("Host", hostname)
+
+                        // Do the request
+                        resp, err := client.Do(req)
+                        if err != nil {
+                                continue
+                        }
+
+                        body, err := ioutil.ReadAll(resp.Body)
+                        if err != nil {
+                                fmt.Println("Error: ", err)
+                                continue
+                        }
+                        text := string(body)
+
+                        lev := levenshtein([]rune(text), []rune(ogBody))
+
+                        if lev <= threshold {
+                                resChan <- "MATCH " + url + " " + strconv.Itoa(lev)
+                        } else {
+                                resChan <- "NOMATCH " + url + " " + strconv.Itoa(lev)
+                        }
+
                 }
-
-                // Check if ip address from stdin is ipv6
-                if strings.Count(ip, ":") >= 2 {
-                        ip = "[" + ip + "]"
-                }
-
-                // Create ip URL
-                ipUrl := u.Scheme + "://" + ip + port + u.Path
-                
-                
-                // Create a request
-                req, err := http.NewRequest("GET", ipUrl, nil)
-                if err != nil {
-                        fmt.Println("Error sending HTTP request", err)
-                        continue
-                }
-
-                // Add the custom host header to the request (can be host:port)
-                req.Host = u.Host
-
-                // Do the request
-                resp, err := client.Do(req)
-                if err != nil {
-                        // Redirects are skipped here silently as errors due to CheckRedirect
-                        continue
-                }
-
-                body, err := ioutil.ReadAll(resp.Body)
-                if err != nil {
-                        fmt.Println("Error: ", err)
-                        continue
-                }
-                text := string(body)
-
-                lev := levenshtein([]rune(text), []rune(ogBody))
-
-                if lev <= threshold {
-                        resChan <- "MATCH " + ipUrl + " " + strconv.Itoa(lev)
-                } else {
-                        resChan <- "NOMATCH " + ipUrl + " " + strconv.Itoa(lev)
-                }
-
         }
 }
 
@@ -118,16 +103,17 @@ func main() {
         // Set up CLI flags
         workers := flag.Int("t", 32, "numbers of threads")
         threshold := flag.Int("l", 5, "levenshtein threshold, higher means more lenient")
-        hostname := flag.String("h", "", "host/url of site, e.g. https://www.hakluke.com:443/blog")
+        hostname := flag.String("h", "", "hostname of site, e.g. www.hakluke.com")
+        hostnameSSL := flag.Bool("s", false, "Original hostname is over SSL (default: false)")
+        hostnamePort := flag.String("p", "", "Original hostname listen port")
         flag.Parse()
 
         // Sanity check, print usage if no hostname specified
-        u, urlerror := url.Parse(*hostname)
-        if urlerror != nil || *hostname == "" {
-                fmt.Println("A list of IP addresses must be provided via stdin, along with an host/URL of the website you are trying to find the origin of.\n\nE.g. prips 1.1.1.0/24 | hakoriginfinder -h https://www.hakluke.com\n\nOptions:")
+        if *hostname == "" {
+                fmt.Println("A list of IP addresses must be provided via stdin, along with a hostname of the website you are trying to find the origin of.\n\nE.g. prips 1.1.1.0/24 | hakoriginfinder -h www.hakluke.com\n\nOptions:")
                 flag.PrintDefaults()
                 os.Exit(2)
-	    }
+        }
 
         // IP addresses are provided via stdin
         scanner := bufio.NewScanner(os.Stdin)
@@ -147,40 +133,10 @@ func main() {
         }
 
         // Set up HTTP client
-        var RedirectAttemptedError = errors.New("redirect")
         var client = &http.Client{
-                Timeout:   time.Second * 5,
+                Timeout:   time.Second * 10,
                 Transport: transport,
-                CheckRedirect: func(req *http.Request, via []*http.Request) error {
-                        return RedirectAttemptedError
-                },
         }
-
-        // Get original URL
-        resp := &http.Response{}
-        var err error
-        resp, err = client.Get(u.Scheme + "://" + u.Host + u.Path)
-        // Handle redirect error
-        for errors.Is(err, RedirectAttemptedError) {
-                redirectUrl, _ := resp.Location()
-                fmt.Println("Redirect", resp.StatusCode, "to:", redirectUrl)
-                u = redirectUrl
-                resp, err = client.Get(u.Scheme + "://" + u.Host + u.Path)
-        }
-        // Handle any error
-        if err != nil {
-                log.Println("Error getting original URL:", err)
-                os.Exit(2)
-        }
-
-        // Read the response
-        body, err := ioutil.ReadAll(resp.Body)
-        if err != nil {
-                log.Fatal("Error reading HTTP response from original host.", err)
-        }
-
-        // Convert body to string
-        ogBody := string(body)
 
         // Set up waitgroup
         var wg sync.WaitGroup
@@ -192,9 +148,46 @@ func main() {
                 close(done)
         }()
 
+        // Get original URL
+        resp := &http.Response{}
+        var err error
+        if *hostnameSSL {
+                port:="443"
+                if *hostnamePort != "" {
+                        port=*hostnamePort
+                } else {
+
+                }
+                resp, err = client.Get("https://" + *hostname + ":"+port)
+                if err != nil {
+                        log.Println("Error getting original URL:", err)
+                        os.Exit(2)
+                }
+        } else {
+                port:="80"
+                if *hostnamePort != "" {
+                        port=*hostnamePort
+                }
+                resp, err = client.Get("http://" + *hostname + ":"+port)
+                if err != nil {
+                        log.Println("Error getting original URL:", err)
+                        os.Exit(2)
+                }
+        }
+
+
+        // Read the response
+        body, err := ioutil.ReadAll(resp.Body)
+        if err != nil {
+                log.Fatal("Error reading HTTP response from original host.", err)
+        }
+
+        // Convert body to string
+        ogBody := string(body)
+
         // Fire up workers
         for i := 0; i < *workers; i++ {
-                go worker(ips, resChan, &wg, client, u, ogBody, *threshold)
+                go worker(ips, resChan, &wg, client, *hostname, ogBody, *threshold)
         }
 
         // Add ips from stdin to ips channel


### PR DESCRIPTION
Reverts hakluke/hakoriginfinder#8

Ah sorry @modrobert I approved this without properly checking it out.

I don't like how this operates because it is very common to host a website somewhere over plain HTTP, and then allow the WAF/reverse proxy to add the SSL for you.

So in that case - this would never be found, because it only checks `https://` now on port 443 instead of both.

I like the concept of specifying a certain path though! Would we be able to implement just this bit? It's also pretty common to not host the origin on port 80/443, but to use custom ports instead. It would be great to be able to support this.