### PR TITLE
Added path, port, scheme and redirect support by handling URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The number of threads may be set with `-t`, default is 32.
 
 The hostname is set with `-h`, there is no default.
 
+The ports to use for the IP addresses supplied via stdin is set with `-p`, the default is 80,443.
+
 ## Output
 
 The output is 3 columns, separated by spaces. The first column is either "MATCH" or "NOMATCH" depending on whether the Levenshtein threshold was reached or not. The second column is the URL being tested, and the third column is the Levenshtein score.


### PR DESCRIPTION
The hakoriginfinder program now handles URL as structure where the hostname given with the -h option can be an URL, e.g.
```
prips 1.1.1.0/24 | hakoriginfinder -h http://one.one.one.one:80/index.html -p 80,443,8080,8443
Redirect 301 to: https://one.one.one.one/index.html
Redirect 308 to: https://one.one.one.one/
--- snip ---
NOMATCH http://1.1.1.250:8443/ 56290
NOMATCH http://1.1.1.252:8443/ 56290
NOMATCH http://1.1.1.254:8443/ 56290
MATCH https://1.1.1.1:8443/ 0
```

This pull request fixes issue https://github.com/hakluke/hakoriginfinder/issues/7 and what @hakluke wrote in PR https://github.com/hakluke/hakoriginfinder/pull/10.