### PR TITLE
Added path, port, scheme and redirect support by handling URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Tool for discovering the origin host behind a reverse proxy. Useful for bypassin
 
 ## How does it work?
 
-This tool will first make a HTTP request to the hostname/URL that you provide and store the response, then it will make a request to every IP address that you provide via HTTP (80) or HTTPS (443) depending on URL, with the `Host` header set to the original host(:port). Each response is then compared to the original using the Levenshtein algorithm to determine similarity. If the response is similar, it will be deemed a match.
+This tool will first make a HTTP request to the hostname/URL that you provide and store the response, then it will make a request to every IP address that you provide via HTTP (80) and HTTPS (443) by default (more ports can be given via option), with the `Host` header set to the original host(:port). Each response is then compared to the original using the Levenshtein algorithm to determine similarity. If the response is similar, it will be deemed a match.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -29,22 +29,28 @@ The output is 3 columns, separated by spaces. The first column is either "MATCH"
 ### Output example
 
 ```
-hakluke$ prips 1.1.1.0/24 | hakoriginfinder -h https://one.one.one.one/index.html
+$ prips 1.1.1.0/24 | hakoriginfinder -h http://one.one.one.one:80/index.html -p 80,443,8080,8443
+Redirect 301 to: https://one.one.one.one/index.html
 Redirect 308 to: https://one.one.one.one/
-NOMATCH http://1.1.1.13:443/ 56290
-NOMATCH http://1.1.1.21:443/ 56290
-NOMATCH http://1.1.1.14:443/ 56290
-NOMATCH http://1.1.1.22:443/ 56290
-NOMATCH http://1.1.1.30:443/ 56290
-NOMATCH http://1.1.1.27:443/ 56290
-NOMATCH http://1.1.1.23:443/ 56290
+NOMATCH http://1.1.1.31:443/ 56290
+NOMATCH http://1.1.1.17:443/ 56290
+NOMATCH http://1.1.1.4:443/ 56290
 NOMATCH http://1.1.1.0:443/ 56290
+NOMATCH http://1.1.1.27:443/ 56290
+NOMATCH http://1.1.1.1:443/ 56290
+NOMATCH http://1.1.1.11:443/ 56290
+NOMATCH http://1.1.1.3:443/ 56290
+NOMATCH http://1.1.1.25:443/ 56290
+NOMATCH http://1.1.1.5:443/ 56290
+NOMATCH http://1.1.1.24:443/ 56290
 ... snipped for brevity ...
-NOMATCH http://1.1.1.252:443/ 56290
-NOMATCH http://1.1.1.253:443/ 56290
-NOMATCH http://1.1.1.254:443/ 56290
-NOMATCH http://1.1.1.251:443/ 56290
+NOMATCH http://1.1.1.185:8443/ 56290
+NOMATCH http://1.1.1.183:8443/ 56290
 MATCH https://1.1.1.1:443/ 0
+... snipped for brevity ...
+NOMATCH http://1.1.1.253:8443/ 56290
+NOMATCH http://1.1.1.252:8443/ 56290
+MATCH https://1.1.1.1:8443/ 0
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -31,9 +31,20 @@ The output is 3 columns, separated by spaces. The first column is either "MATCH"
 ```
 hakluke$ prips 1.1.1.0/24 | hakoriginfinder -h https://one.one.one.one/index.html
 Redirect 308 to: https://one.one.one.one/
-NOMATCH https://1.1.1.2/ 56383
-NOMATCH https://1.1.1.3/ 56383
-MATCH https://1.1.1.1/ 0
+NOMATCH http://1.1.1.13:443/ 56290
+NOMATCH http://1.1.1.21:443/ 56290
+NOMATCH http://1.1.1.14:443/ 56290
+NOMATCH http://1.1.1.22:443/ 56290
+NOMATCH http://1.1.1.30:443/ 56290
+NOMATCH http://1.1.1.27:443/ 56290
+NOMATCH http://1.1.1.23:443/ 56290
+NOMATCH http://1.1.1.0:443/ 56290
+... snipped for brevity ...
+NOMATCH http://1.1.1.252:443/ 56290
+NOMATCH http://1.1.1.253:443/ 56290
+NOMATCH http://1.1.1.254:443/ 56290
+NOMATCH http://1.1.1.251:443/ 56290
+MATCH https://1.1.1.1:443/ 0
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Tool for discovering the origin host behind a reverse proxy. Useful for bypassin
 
 ## How does it work?
 
-This tool will first make a HTTP request to the hostname that you provide and store the response, then it will make a request to every IP address that you provide via HTTP (80) and HTTPS (443), with the `Host` header set to the original host. Each HTTP response is then compared to the original using the Levenshtein algorithm to determine similarity. If the response is similar, it will be deemed a match.
+This tool will first make a HTTP request to the hostname/URL that you provide and store the response, then it will make a request to every IP address that you provide via HTTP (80) or HTTPS (443) depending on URL, with the `Host` header set to the original host(:port). Each response is then compared to the original using the Levenshtein algorithm to determine similarity. If the response is similar, it will be deemed a match.
 
 ## Usage
 
 Provide the list of IP addresses via stdin, and the original hostname via the -h option. For example:
 
 ```
-prips 93.184.216.0/24 | hakoriginfinder -h example.com
+prips 93.184.216.0/24 | hakoriginfinder -h https://example.com:443/foo
 ```
 
 You may set the Levenshtein distance threshold with `-l`. The lower the number, the more similar the matches need to be for it to be considered a match, the default is 5.
@@ -20,6 +20,8 @@ The number of threads may be set with `-t`, default is 32.
 
 The hostname is set with `-h`, there is no default.
 
+The ports to use for the IP addresses supplied via stdin is set with `-p`, the default is 80,443.
+
 ## Output
 
 The output is 3 columns, separated by spaces. The first column is either "MATCH" or "NOMATCH" depending on whether the Levenshtein threshold was reached or not. The second column is the URL being tested, and the third column is the Levenshtein score.
@@ -27,27 +29,11 @@ The output is 3 columns, separated by spaces. The first column is either "MATCH"
 ### Output example
 
 ```
-hakluke$ prips 1.1.1.0/24 | hakoriginfinder -h one.one.one.one
-NOMATCH http://1.1.1.0 54366
-NOMATCH http://1.1.1.30 54366
-NOMATCH http://1.1.1.20 54366
-NOMATCH http://1.1.1.4 54366
-NOMATCH http://1.1.1.11 54366
-NOMATCH http://1.1.1.5 54366
-NOMATCH http://1.1.1.22 54366
-NOMATCH http://1.1.1.13 54366
-NOMATCH http://1.1.1.10 54366
-NOMATCH http://1.1.1.25 54366
-NOMATCH http://1.1.1.19 54366
-... snipped for brevity ...
-NOMATCH http://1.1.1.251 54366
-NOMATCH http://1.1.1.248 54366
-MATCH http://1.1.1.1 0
-NOMATCH http://1.1.1.3 19567
-NOMATCH http://1.1.1.2 19517
-MATCH https://1.1.1.1 0
-NOMATCH https://1.1.1.3 19534
-NOMATCH https://1.1.1.2 19532
+hakluke$ prips 1.1.1.0/24 | hakoriginfinder -h https://one.one.one.one/index.html
+Redirect 308 to: https://one.one.one.one/
+NOMATCH https://1.1.1.2/ 56383
+NOMATCH https://1.1.1.3/ 56383
+MATCH https://1.1.1.1/ 0
 ```
 
 ## Installation

--- a/hakoriginfinder.go
+++ b/hakoriginfinder.go
@@ -3,13 +3,16 @@ package main
 import (
         "bufio"
         "crypto/tls"
+        "errors"
         "flag"
         "fmt"
         "io/ioutil"
         "log"
         "net/http"
+        "net/url"
         "os"
         "strconv"
+        "strings"
         "sync"
         "time"
 )
@@ -55,45 +58,56 @@ func minimum(a, b, c int) int {
 }
 
 // Make HTTP request, check response
-func worker(ips <-chan string, resChan chan<- string, wg *sync.WaitGroup, client *http.Client, hostname string, ogBody string, threshold int) {
+func worker(ips <-chan string, resChan chan<- string, wg *sync.WaitGroup, client *http.Client, u *url.URL, ogBody string, threshold int, ports []string) {
         defer wg.Done()
         for ip := range ips {
+                // http and https schemes
+                schemes := []string{"http", "https"}
+                for _, scheme := range schemes {
+                        for _, port := range ports {
 
-                // make a http and https url
-                urls := []string{"http://" + ip, "https://" + ip}
+                                // Check if ip address from stdin is ipv6
+                                if strings.Count(ip, ":") >= 2 {
+                                        ip = "[" + ip + "]"
+                                }
 
-                for _, url := range urls {
-                        // Create a request
-                        req, err := http.NewRequest("GET", url, nil)
-                        if err != nil {
-                                fmt.Println("Error sending HTTP request", err)
-                                continue
+                                // Create ip URL
+                                ipUrl := scheme + "://" + ip + ":" + port + u.Path
+                                
+                                // Create a request
+                                req, err := http.NewRequest("GET", ipUrl, nil)
+                                if err != nil {
+                                        fmt.Println("Error sending HTTP request", err)
+                                        continue
+                                }
+
+                                // Add the custom host header to the request (can be host:port)
+                                req.Host = u.Host
+
+                                // Do the request
+                                resp, err := client.Do(req)
+                                if err != nil {
+                                        // Redirects are skipped here silently as errors
+                                        // due to CheckRedirect
+                                        continue
+                                }
+
+                                body, err := ioutil.ReadAll(resp.Body)
+                                if err != nil {
+                                        fmt.Println("Error: ", err)
+                                        continue
+                                }
+                                text := string(body)
+
+                                lev := levenshtein([]rune(text), []rune(ogBody))
+
+                                if lev <= threshold {
+                                        resChan <- "MATCH " + ipUrl + " " + strconv.Itoa(lev)
+                                } else {
+                                        resChan <- "NOMATCH " + ipUrl + " " + strconv.Itoa(lev)
+
+                                }
                         }
-
-                        // Add the custom host header to the request
-                        req.Header.Add("Host", hostname)
-
-                        // Do the request
-                        resp, err := client.Do(req)
-                        if err != nil {
-                                continue
-                        }
-
-                        body, err := ioutil.ReadAll(resp.Body)
-                        if err != nil {
-                                fmt.Println("Error: ", err)
-                                continue
-                        }
-                        text := string(body)
-
-                        lev := levenshtein([]rune(text), []rune(ogBody))
-
-                        if lev <= threshold {
-                                resChan <- "MATCH " + url + " " + strconv.Itoa(lev)
-                        } else {
-                                resChan <- "NOMATCH " + url + " " + strconv.Itoa(lev)
-                        }
-
                 }
         }
 }
@@ -103,17 +117,20 @@ func main() {
         // Set up CLI flags
         workers := flag.Int("t", 32, "numbers of threads")
         threshold := flag.Int("l", 5, "levenshtein threshold, higher means more lenient")
-        hostname := flag.String("h", "", "hostname of site, e.g. www.hakluke.com")
-        hostnameSSL := flag.Bool("s", false, "Original hostname is over SSL (default: false)")
-        hostnamePort := flag.String("p", "", "Original hostname listen port")
+        hostname := flag.String("h", "", "scheme://host[:port]/url of site, e.g. https://www.hakluke.com:443/blog")
+        scanPorts := flag.String("p", "80,443", "comma separated ports to scan for IP addresses given via stdin, e.g. 80,443,8000,8080,8443")
         flag.Parse()
 
         // Sanity check, print usage if no hostname specified
-        if *hostname == "" {
-                fmt.Println("A list of IP addresses must be provided via stdin, along with a hostname of the website you are trying to find the origin of.\n\nE.g. prips 1.1.1.0/24 | hakoriginfinder -h www.hakluke.com\n\nOptions:")
+        u, urlerror := url.Parse(*hostname)
+        if urlerror != nil || *hostname == "" {
+                fmt.Println("A list of IP addresses must be provided via stdin, along with an host/URL of the website you are trying to find the origin of.\n\nE.g. prips 1.1.1.0/24 | hakoriginfinder -h https://www.hakluke.com\n\nOptions:")
                 flag.PrintDefaults()
                 os.Exit(2)
-        }
+	    }
+
+        // Handle ports argument
+        ports := strings.Split(*scanPorts, ",")
 
         // IP addresses are provided via stdin
         scanner := bufio.NewScanner(os.Stdin)
@@ -133,10 +150,40 @@ func main() {
         }
 
         // Set up HTTP client
+        var RedirectAttemptedError = errors.New("redirect")
         var client = &http.Client{
-                Timeout:   time.Second * 10,
+                Timeout:   time.Second * 5,
                 Transport: transport,
+                CheckRedirect: func(req *http.Request, via []*http.Request) error {
+                        return RedirectAttemptedError
+                },
         }
+
+        // Get original URL
+        resp := &http.Response{}
+        var err error
+        resp, err = client.Get(u.Scheme + "://" + u.Host + u.Path)
+        // Handle redirect error
+        for errors.Is(err, RedirectAttemptedError) {
+                redirectUrl, _ := resp.Location()
+                fmt.Println("Redirect", resp.StatusCode, "to:", redirectUrl)
+                u = redirectUrl
+                resp, err = client.Get(u.Scheme + "://" + u.Host + u.Path)
+        }
+        // Handle any error
+        if err != nil {
+                log.Println("Error getting original URL:", err)
+                os.Exit(2)
+        }
+
+        // Read the response
+        body, err := ioutil.ReadAll(resp.Body)
+        if err != nil {
+                log.Fatal("Error reading HTTP response from original host.", err)
+        }
+
+        // Convert body to string
+        ogBody := string(body)
 
         // Set up waitgroup
         var wg sync.WaitGroup
@@ -148,46 +195,9 @@ func main() {
                 close(done)
         }()
 
-        // Get original URL
-        resp := &http.Response{}
-        var err error
-        if *hostnameSSL {
-                port:="443"
-                if *hostnamePort != "" {
-                        port=*hostnamePort
-                } else {
-
-                }
-                resp, err = client.Get("https://" + *hostname + ":"+port)
-                if err != nil {
-                        log.Println("Error getting original URL:", err)
-                        os.Exit(2)
-                }
-        } else {
-                port:="80"
-                if *hostnamePort != "" {
-                        port=*hostnamePort
-                }
-                resp, err = client.Get("http://" + *hostname + ":"+port)
-                if err != nil {
-                        log.Println("Error getting original URL:", err)
-                        os.Exit(2)
-                }
-        }
-
-
-        // Read the response
-        body, err := ioutil.ReadAll(resp.Body)
-        if err != nil {
-                log.Fatal("Error reading HTTP response from original host.", err)
-        }
-
-        // Convert body to string
-        ogBody := string(body)
-
         // Fire up workers
         for i := 0; i < *workers; i++ {
-                go worker(ips, resChan, &wg, client, *hostname, ogBody, *threshold)
+                go worker(ips, resChan, &wg, client, u, ogBody, *threshold, ports)
         }
 
         // Add ips from stdin to ips channel


### PR DESCRIPTION
The hakoriginfinder program now handles URL as structure where the hostname given with the -h option can be an URL, e.g.
```
prips 1.1.1.0/24 | hakoriginfinder -h http://one.one.one.one:80/index.html -p 80,443,8080,8443
Redirect 301 to: https://one.one.one.one/index.html
Redirect 308 to: https://one.one.one.one/
--- snip ---
NOMATCH http://1.1.1.250:8443/ 56290
NOMATCH http://1.1.1.252:8443/ 56290
NOMATCH http://1.1.1.254:8443/ 56290
MATCH https://1.1.1.1:8443/ 0
```

This pull request fixes issue https://github.com/hakluke/hakoriginfinder/issues/7 and what @hakluke wrote in PR https://github.com/hakluke/hakoriginfinder/pull/10.