### PR TITLE
Fix HTTPS false negatives by setting TLS SNI to target hostname

### DIFF
--- a/hakoriginfinder.go
+++ b/hakoriginfinder.go
@@ -185,6 +185,11 @@ func main() {
         // Convert body to string
         ogBody := string(body)
 
+        // Set TLS ServerName (SNI) to the target hostname so that HTTPS
+        // requests to candidate IPs present the correct SNI value. Without
+        // this, servers that route by SNI would not recognise the request.
+        transport.TLSClientConfig.ServerName = u.Hostname()
+
         // Set up waitgroup
         var wg sync.WaitGroup
         wg.Add(*workers)


### PR DESCRIPTION
When scanning candidate IPs over HTTPS, the TLS ClientHello was sending the raw IP as the SNI value instead of the target hostname. Servers that route by SNI (common in shared hosting, CDNs, and cloud environments) would serve a default/wrong backend, causing the tool to report false negative even when the real origin IP was found.